### PR TITLE
remove OP from names of circuits in audit scope

### DIFF
--- a/circuits/circuits/dsc/dsc.circom
+++ b/circuits/circuits/dsc/dsc.circom
@@ -11,7 +11,7 @@ include "../utils/passport/signatureVerifier.circom";
 include "@zk-email/circuits/utils/bytes.circom";
 
 
-template OPENPASSPORT_DSC(signatureAlgorithm, n_dsc, k_dsc, n_csca, k_csca, max_cert_bytes, dscPubkeyBytesLength, nLevels) {
+template DSC(signatureAlgorithm, n_dsc, k_dsc, n_csca, k_csca, max_cert_bytes, dscPubkeyBytesLength, nLevels) {
    
     // variables verification
     assert(max_cert_bytes % 64 == 0);

--- a/circuits/circuits/dsc/instances/dsc_rsa_sha1_65537_4096.circom
+++ b/circuits/circuits/dsc/instances/dsc_rsa_sha1_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_dsc.circom";
+include "../dsc.circom";
 
-component main { public [ merkle_root ] } = OPENPASSPORT_DSC(11, 120, 35, 120, 35, 1664, 256, 12);
+component main { public [ merkle_root ] } = DSC(11, 120, 35, 120, 35, 1664, 256, 12);

--- a/circuits/circuits/dsc/instances/dsc_rsa_sha256_65537_4096.circom
+++ b/circuits/circuits/dsc/instances/dsc_rsa_sha256_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_dsc.circom";
+include "../dsc.circom";
 
-component main { public [ merkle_root ] } = OPENPASSPORT_DSC(10, 120, 35, 120, 35, 1664, 256, 12);
+component main { public [ merkle_root ] } = DSC(10, 120, 35, 120, 35, 1664, 256, 12);

--- a/circuits/circuits/dsc/instances/dsc_rsapss_sha256_65537_4096.circom
+++ b/circuits/circuits/dsc/instances/dsc_rsapss_sha256_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_dsc.circom";
+include "../dsc.circom";
 
-component main { public [ merkle_root ] } = OPENPASSPORT_DSC(12, 120, 35, 120, 35, 1664, 256, 12);
+component main { public [ merkle_root ] } = DSC(12, 120, 35, 120, 35, 1664, 256, 12);

--- a/circuits/circuits/register/instances/register_sha1_sha1_sha1_ecdsa_brainpoolP224r1.circom
+++ b/circuits/circuits/register/instances/register_sha1_sha1_sha1_ecdsa_brainpoolP224r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(160, 160, 27, 32, 7, 320, 128);
+component main = REGISTER(160, 160, 27, 32, 7, 320, 128);

--- a/circuits/circuits/register/instances/register_sha1_sha1_sha1_ecdsa_secp256r1.circom
+++ b/circuits/circuits/register/instances/register_sha1_sha1_sha1_ecdsa_secp256r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(160, 160, 7, 64, 4, 320, 128);
+component main = REGISTER(160, 160, 7, 64, 4, 320, 128);

--- a/circuits/circuits/register/instances/register_sha1_sha1_sha1_rsa_65537_2048.circom
+++ b/circuits/circuits/register/instances/register_sha1_sha1_sha1_rsa_65537_2048.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(160, 160 , 3, 64, 32, 320, 128);
+component main = REGISTER(160, 160 , 3, 64, 32, 320, 128);

--- a/circuits/circuits/register/instances/register_sha1_sha256_sha256_rsa_65537_4096.circom
+++ b/circuits/circuits/register/instances/register_sha1_sha256_sha256_rsa_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main  = OPENPASSPORT_REGISTER(160, 256 , 1, 120, 35, 320, 128);
+component main  = REGISTER(160, 256 , 1, 120, 35, 320, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha224_sha224_ecdsa_brainpoolP224r1.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha224_sha224_ecdsa_brainpoolP224r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 224, 30, 32, 7, 448, 128);
+component main = REGISTER(256, 224, 30, 32, 7, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_brainpoolP224r1.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_brainpoolP224r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 256, 28, 32, 7, 448, 128);
+component main = REGISTER(256, 256, 28, 32, 7, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_brainpoolP256r1.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_brainpoolP256r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 256, 21, 64, 4, 448, 128);
+component main = REGISTER(256, 256, 21, 64, 4, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_secp256r1.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_secp256r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 256, 8, 64, 4, 448, 128);
+component main = REGISTER(256, 256, 8, 64, 4, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_secp384r1.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_ecdsa_secp384r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 256, 23, 64, 6, 448, 128);
+component main = REGISTER(256, 256, 23, 64, 6, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_3_4096.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_3_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(256, 256, 13, 120, 35, 448, 128);
+component main = REGISTER(256, 256, 13, 120, 35, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_65537_3072.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_65537_3072.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main { public [ scope, user_identifier, current_date ] } = OPENPASSPORT_REGISTER(256, 256, 14, 96, 32, 448, 128);
+component main { public [ scope, user_identifier, current_date ] } = REGISTER(256, 256, 14, 96, 32, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_65537_4096.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsa_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main  = OPENPASSPORT_REGISTER(256 ,256 ,1, 120, 35, 448, 128);
+component main  = REGISTER(256 ,256 ,1, 120, 35, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsapss_3_4096.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsapss_3_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main  = OPENPASSPORT_REGISTER(256,256, 17, 120, 35, 448, 128);
+component main  = REGISTER(256,256, 17, 120, 35, 448, 128);

--- a/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsapss_65537_4096.circom
+++ b/circuits/circuits/register/instances/register_sha256_sha256_sha256_rsapss_65537_4096.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main  = OPENPASSPORT_REGISTER(256, 256, 12, 120, 35, 448, 128);
+component main  = REGISTER(256, 256, 12, 120, 35, 448, 128);

--- a/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_brainpoolP256r1.circom
+++ b/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_brainpoolP256r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(384, 384, 24, 64, 4, 640, 256);
+component main = REGISTER(384, 384, 24, 64, 4, 640, 256);

--- a/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_brainpoolP384r1.circom
+++ b/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_brainpoolP384r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(384, 384, 22, 64, 6, 640, 256);
+component main = REGISTER(384, 384, 22, 64, 6, 640, 256);

--- a/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_secp384r1.circom
+++ b/circuits/circuits/register/instances/register_sha384_sha384_sha384_ecdsa_secp384r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(384, 384, 9, 64, 6, 640, 256);
+component main = REGISTER(384, 384, 9, 64, 6, 640, 256);

--- a/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP256r1.circom
+++ b/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP256r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(512, 512, 25, 64, 4, 768, 256);
+component main = REGISTER(512, 512, 25, 64, 4, 768, 256);

--- a/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP384r1.circom
+++ b/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP384r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(512, 512, 26, 64, 6, 768, 256);
+component main = REGISTER(512, 512, 26, 64, 6, 768, 256);

--- a/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP512r1.circom
+++ b/circuits/circuits/register/instances/register_sha512_sha512_sha512_ecdsa_brainpoolP512r1.circom
@@ -1,5 +1,5 @@
 pragma circom 2.1.9;
 
-include "../openpassport_register.circom";
+include "../register.circom";
 
-component main = OPENPASSPORT_REGISTER(512, 512, 29, 64, 8, 768, 256);
+component main = REGISTER(512, 512, 29, 64, 8, 768, 256);

--- a/circuits/circuits/register/register.circom
+++ b/circuits/circuits/register/register.circom
@@ -10,7 +10,7 @@ include "../utils/passport/disclose/disclose.circom";
 include "../utils/passport/disclose/proveCountryIsNotInList.circom";
 include "../utils/passport/ofac/ofac_name.circom";
 
-template OPENPASSPORT_REGISTER(DG_HASH_ALGO, ECONTENT_HASH_ALGO, signatureAlgorithm, n, k, MAX_ECONTENT_PADDED_LEN, MAX_SIGNED_ATTR_PADDED_LEN) {
+template REGISTER(DG_HASH_ALGO, ECONTENT_HASH_ALGO, signatureAlgorithm, n, k, MAX_ECONTENT_PADDED_LEN, MAX_SIGNED_ATTR_PADDED_LEN) {
     var kLengthFactor = getKLengthFactor(signatureAlgorithm);
     var kScaled = k * kLengthFactor;
     var HASH_LEN_BITS = getHashLength(signatureAlgorithm);


### PR DESCRIPTION
Remove name OpenPassport from circuits in the audit scope. This is so that circuits are general and don't need to be edited after an audit if any renaming were to occur.