### PR TITLE
Remove DG2 reading 

### DIFF
--- a/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
+++ b/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
@@ -364,9 +364,9 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
 
                 
                 val dg1In = service.getInputStream(PassportService.EF_DG1)
-                dg1File = DG1File(dg1In)   
-                val dg2In = service.getInputStream(PassportService.EF_DG2)
-                dg2File = DG2File(dg2In)                
+                dg1File = DG1File(dg1In)
+                // val dg2In = service.getInputStream(PassportService.EF_DG2)
+                // dg2File = DG2File(dg2In)
                 val sodIn = service.getInputStream(PassportService.EF_SOD)
                 sodFile = SODFile(sodIn)
                 
@@ -406,20 +406,20 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
                 // sendDataToJS(PassportData(dg1File, dg2File, sodFile))
                 // Log.d(TAG, "============DATA SENT TO JS=============")
 
-                val allFaceImageInfo: MutableList<FaceImageInfo> = ArrayList()
-                dg2File.faceInfos.forEach {
-                    allFaceImageInfo.addAll(it.faceImageInfos)
-                }
-                if (allFaceImageInfo.isNotEmpty()) {
-                    val faceImageInfo = allFaceImageInfo.first()
-                    val imageLength = faceImageInfo.imageLength
-                    val dataInputStream = DataInputStream(faceImageInfo.imageInputStream)
-                    val buffer = ByteArray(imageLength)
-                    dataInputStream.readFully(buffer, 0, imageLength)
-                    val inputStream: InputStream = ByteArrayInputStream(buffer, 0, imageLength)
-                    bitmap = decodeImage(reactContext, faceImageInfo.mimeType, inputStream)
-                    imageBase64 = Base64.encodeToString(buffer, Base64.DEFAULT)
-                }
+                // val allFaceImageInfo: MutableList<FaceImageInfo> = ArrayList()
+                // dg2File.faceInfos.forEach {
+                //     allFaceImageInfo.addAll(it.faceImageInfos)
+                // }
+                // if (allFaceImageInfo.isNotEmpty()) {
+                //     val faceImageInfo = allFaceImageInfo.first()
+                //     val imageLength = faceImageInfo.imageLength
+                //     val dataInputStream = DataInputStream(faceImageInfo.imageInputStream)
+                //     val buffer = ByteArray(imageLength)
+                //     dataInputStream.readFully(buffer, 0, imageLength)
+                //     val inputStream: InputStream = ByteArrayInputStream(buffer, 0, imageLength)
+                //     bitmap = decodeImage(reactContext, faceImageInfo.mimeType, inputStream)
+                //     imageBase64 = Base64.encodeToString(buffer, Base64.DEFAULT)
+                // }
             } catch (e: Exception) {
                 eventMessageEmitter(Messages.RESET)
                 return e
@@ -660,13 +660,13 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
             //   Log.d(TAG, "signedData.signerInfos: ${gson.toJson(signedData.signerInfos)}")
             //   Log.d(TAG, "signedData.certificates: ${gson.toJson(signedData.certificates)}")
             
-            var quality = 100
-            val base64 = bitmap?.let { toBase64(it, quality) }
-            val photo = Arguments.createMap()
-            photo.putString("base64", base64 ?: "")
-            photo.putInt("width", bitmap?.width ?: 0)
-            photo.putInt("height", bitmap?.height ?: 0)
-            passport.putMap("photo", photo)
+            // var quality = 100
+            // val base64 = bitmap?.let { toBase64(it, quality) }
+            // val photo = Arguments.createMap()
+            // photo.putString("base64", base64 ?: "")
+            // photo.putInt("width", bitmap?.width ?: 0)
+            // photo.putInt("height", bitmap?.height ?: 0)
+            // passport.putMap("photo", photo)
             // passport.putString("dg2File", gson.toJson(dg2File))
             
             eventMessageEmitter(Messages.COMPLETED)

--- a/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
+++ b/app/android/react-native-passport-reader/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.kt
@@ -362,11 +362,13 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
                     }
                 }
 
-                
+                eventMessageEmitter("Reading DG1.....")
                 val dg1In = service.getInputStream(PassportService.EF_DG1)
                 dg1File = DG1File(dg1In)
+                // eventMessageEmitter("Reading DG2.....")
                 // val dg2In = service.getInputStream(PassportService.EF_DG2)
                 // dg2File = DG2File(dg2In)
+                eventMessageEmitter("Reading SOD.....")
                 val sodIn = service.getInputStream(PassportService.EF_SOD)
                 sodFile = SODFile(sodIn)
                 
@@ -429,6 +431,7 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
 
         private fun doChipAuth(service: PassportService) {
             try {
+                eventMessageEmitter("Reading DG14.....")
                 val dg14In = service.getInputStream(PassportService.EF_DG14)
                 dg14Encoded = IOUtils.toByteArray(dg14In)
                 val dg14InByte = ByteArrayInputStream(dg14Encoded)
@@ -459,11 +462,8 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
                 
                 val dataHashes = sodFile.dataGroupHashes
                 
-                eventMessageEmitter("Reading DG14.....")
                 val dg14Hash = if (chipAuthSucceeded) digest.digest(dg14Encoded) else ByteArray(0)
-                eventMessageEmitter("Reading DG1.....")
                 val dg1Hash = digest.digest(dg1File.encoded)
-                eventMessageEmitter("Reading DG2.....")
                 val dg2Hash = digest.digest(dg2File.encoded)
                 
                 // val gson = Gson()
@@ -486,7 +486,8 @@ class RNPassportReaderModule(private val reactContext: ReactApplicationContext) 
 
                 Log.d(TAG, "Comparing data group hashes...")
                 eventMessageEmitter(Messages.COMPARING)
-                if (Arrays.equals(dg1Hash, dataHashes[1]) && Arrays.equals(dg2Hash, dataHashes[2])
+                // if (Arrays.equals(dg1Hash, dataHashes[1]) && Arrays.equals(dg2Hash, dataHashes[2])
+                if (Arrays.equals(dg1Hash, dataHashes[1])
                     && (!chipAuthSucceeded || Arrays.equals(dg14Hash, dataHashes[14]))) {
 
                     Log.d(TAG, "Data group hashes match.")

--- a/app/ios/OpenPassport.xcodeproj/project.pbxproj
+++ b/app/ios/OpenPassport.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		1686F0E02C500FBD00841CDE /* QRScannerBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */; };
 		16E6646E2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */; };
 		16E884A52C5BD764003B7125 /* passport.json in Resources */ = {isa = PBXBuildFile; fileRef = 16E884A42C5BD764003B7125 /* passport.json */; };
-		4EA500B1D4D6BAC54A773C10 /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */; };
+		7FD380C6602D2837D428451F /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59652A81D389205A1361E60D /* Pods_OpenPassport.framework */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		905B70052A72767900AFA232 /* PassportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905B70042A72767900AFA232 /* PassportReader.swift */; };
 		905B70072A72774000AFA232 /* PassportReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B70062A72774000AFA232 /* PassportReader.m */; };
@@ -109,19 +109,19 @@
 		1686F0DB2C500F3800841CDE /* QRScannerBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerBridge.swift; sourceTree = "<group>"; };
 		1686F0DD2C500F4F00841CDE /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
 		1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QRScannerBridge.m; sourceTree = "<group>"; };
-		1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		169349842CC694DA00166F21 /* OpenPassportDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassportDebug.entitlements; path = OpenPassport/OpenPassportDebug.entitlements; sourceTree = "<group>"; };
 		16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QKMRZScannerViewRepresentable.swift; sourceTree = "<group>"; };
 		16E884A42C5BD764003B7125 /* passport.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = passport.json; sourceTree = "<group>"; };
+		59652A81D389205A1361E60D /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = OpenPassport/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		905B70032A72767800AFA232 /* OpenPassport-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OpenPassport-Bridging-Header.h"; sourceTree = "<group>"; };
 		905B70042A72767900AFA232 /* PassportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassportReader.swift; sourceTree = "<group>"; };
 		905B70062A72774000AFA232 /* PassportReader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PassportReader.m; sourceTree = "<group>"; };
 		905B70082A729CD400AFA232 /* OpenPassport.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassport.entitlements; path = OpenPassport/OpenPassport.entitlements; sourceTree = "<group>"; };
-		AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
+		BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
+		E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
 		E56E082698598B41447667BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = OpenPassport/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,7 +140,7 @@
 				05D985F62BB331AB00F58EEA /* libfr.a in Frameworks */,
 				167D934A2C91D2EA00530E6B /* libwitnesscalc_prove_rsa_65537_sha256.a in Frameworks */,
 				167D93462C91B1E100530E6B /* libwitnesscalc_register_rsa_65537_sha1.a in Frameworks */,
-				4EA500B1D4D6BAC54A773C10 /* Pods_OpenPassport.framework in Frameworks */,
+				7FD380C6602D2837D428451F /* Pods_OpenPassport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,7 +227,7 @@
 				0569F35E2BBC98C9006670BD /* libfq.a */,
 				0569F35A2BBC900D006670BD /* librapidsnark.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */,
+				59652A81D389205A1361E60D /* Pods_OpenPassport.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -274,8 +274,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */,
-				FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */,
+				E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */,
+				BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -287,15 +287,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "OpenPassport" */;
 			buildPhases = (
-				FA5A9B9B914E6CE9ED23DBD0 /* [CP] Check Pods Manifest.lock */,
+				F5F9EF6F1544331166222AC0 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				054340D12C71B2980014B445 /* Embed App Clips */,
-				1388239F34831C0D06F22094 /* [CP] Embed Pods Frameworks */,
-				FF7F470DDF762A31EA779AA5 /* [CP] Copy Pods Resources */,
+				C7FE745AC5EB974886200FC9 /* [CP] Embed Pods Frameworks */,
+				AAC3293A7CD5BBE029F392E0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -369,7 +369,24 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		1388239F34831C0D06F22094 /* [CP] Embed Pods Frameworks */ = {
+		AAC3293A7CD5BBE029F392E0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C7FE745AC5EB974886200FC9 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -386,7 +403,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FA5A9B9B914E6CE9ED23DBD0 /* [CP] Check Pods Manifest.lock */ = {
+		F5F9EF6F1544331166222AC0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -425,23 +442,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		FF7F470DDF762A31EA779AA5 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -492,7 +492,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */;
+			baseConfigurationReference = E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -633,7 +633,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */;
+			baseConfigurationReference = BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/app/ios/OpenPassport.xcodeproj/project.pbxproj
+++ b/app/ios/OpenPassport.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		1686F0E02C500FBD00841CDE /* QRScannerBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */; };
 		16E6646E2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */; };
 		16E884A52C5BD764003B7125 /* passport.json in Resources */ = {isa = PBXBuildFile; fileRef = 16E884A42C5BD764003B7125 /* passport.json */; };
-		1B904271B8E1DB8434EF0613 /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3435ED6D988B5E2DE0DE8101 /* Pods_OpenPassport.framework */; };
+		4EA500B1D4D6BAC54A773C10 /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		905B70052A72767900AFA232 /* PassportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905B70042A72767900AFA232 /* PassportReader.swift */; };
 		905B70072A72774000AFA232 /* PassportReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B70062A72774000AFA232 /* PassportReader.m */; };
@@ -109,19 +109,19 @@
 		1686F0DB2C500F3800841CDE /* QRScannerBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerBridge.swift; sourceTree = "<group>"; };
 		1686F0DD2C500F4F00841CDE /* QRScannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRScannerViewController.swift; sourceTree = "<group>"; };
 		1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QRScannerBridge.m; sourceTree = "<group>"; };
+		1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		169349842CC694DA00166F21 /* OpenPassportDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassportDebug.entitlements; path = OpenPassport/OpenPassportDebug.entitlements; sourceTree = "<group>"; };
 		16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QKMRZScannerViewRepresentable.swift; sourceTree = "<group>"; };
 		16E884A42C5BD764003B7125 /* passport.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = passport.json; sourceTree = "<group>"; };
-		3435ED6D988B5E2DE0DE8101 /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = OpenPassport/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		905B70032A72767800AFA232 /* OpenPassport-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OpenPassport-Bridging-Header.h"; sourceTree = "<group>"; };
 		905B70042A72767900AFA232 /* PassportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassportReader.swift; sourceTree = "<group>"; };
 		905B70062A72774000AFA232 /* PassportReader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PassportReader.m; sourceTree = "<group>"; };
 		905B70082A729CD400AFA232 /* OpenPassport.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassport.entitlements; path = OpenPassport/OpenPassport.entitlements; sourceTree = "<group>"; };
-		A239B1BBD7EF208EB51EF7DE /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
-		BB9316819FB038104D42933E /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
+		AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
 		E56E082698598B41447667BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = OpenPassport/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,7 +140,7 @@
 				05D985F62BB331AB00F58EEA /* libfr.a in Frameworks */,
 				167D934A2C91D2EA00530E6B /* libwitnesscalc_prove_rsa_65537_sha256.a in Frameworks */,
 				167D93462C91B1E100530E6B /* libwitnesscalc_register_rsa_65537_sha1.a in Frameworks */,
-				1B904271B8E1DB8434EF0613 /* Pods_OpenPassport.framework in Frameworks */,
+				4EA500B1D4D6BAC54A773C10 /* Pods_OpenPassport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,7 +227,7 @@
 				0569F35E2BBC98C9006670BD /* libfq.a */,
 				0569F35A2BBC900D006670BD /* librapidsnark.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				3435ED6D988B5E2DE0DE8101 /* Pods_OpenPassport.framework */,
+				1687B09E7DC05BC48747CEEE /* Pods_OpenPassport.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -274,8 +274,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BB9316819FB038104D42933E /* Pods-OpenPassport.debug.xcconfig */,
-				A239B1BBD7EF208EB51EF7DE /* Pods-OpenPassport.release.xcconfig */,
+				AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */,
+				FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -287,15 +287,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "OpenPassport" */;
 			buildPhases = (
-				62212FE980074600640A3F2F /* [CP] Check Pods Manifest.lock */,
+				FA5A9B9B914E6CE9ED23DBD0 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				054340D12C71B2980014B445 /* Embed App Clips */,
-				19B6B230BF58128B7603B834 /* [CP] Embed Pods Frameworks */,
-				CCF107224BF9CF7E8A4F57B7 /* [CP] Copy Pods Resources */,
+				1388239F34831C0D06F22094 /* [CP] Embed Pods Frameworks */,
+				FF7F470DDF762A31EA779AA5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -369,7 +369,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		19B6B230BF58128B7603B834 /* [CP] Embed Pods Frameworks */ = {
+		1388239F34831C0D06F22094 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -386,7 +386,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		62212FE980074600640A3F2F /* [CP] Check Pods Manifest.lock */ = {
+		FA5A9B9B914E6CE9ED23DBD0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -408,23 +408,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CCF107224BF9CF7E8A4F57B7 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -442,6 +425,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export RCT_METRO_PORT=\"${RCT_METRO_PORT:=8081}\"\necho \"export RCT_METRO_PORT=${RCT_METRO_PORT}\" > \"${SRCROOT}/../node_modules/react-native/scripts/.packager.env\"\nif [ -z \"${RCT_NO_LAUNCH_PACKAGER+xxx}\" ] ; then\n  if nc -w 5 -z localhost ${RCT_METRO_PORT} ; then\n    if ! curl -s \"http://localhost:${RCT_METRO_PORT}/status\" | grep -q \"packager-status:running\" ; then\n      echo \"Port ${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\"\n      exit 2\n    fi\n  else\n    open \"$SRCROOT/../node_modules/react-native/scripts/launchPackager.command\" || echo \"Can't start packager automatically\"\n  fi\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		FF7F470DDF762A31EA779AA5 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -492,7 +492,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BB9316819FB038104D42933E /* Pods-OpenPassport.debug.xcconfig */;
+			baseConfigurationReference = AFD9855187878C0952D37584 /* Pods-OpenPassport.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -633,7 +633,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A239B1BBD7EF208EB51EF7DE /* Pods-OpenPassport.release.xcconfig */;
+			baseConfigurationReference = FD30D0605CF9CA9B3B3817AB /* Pods-OpenPassport.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/app/ios/OpenPassport.xcodeproj/project.pbxproj
+++ b/app/ios/OpenPassport.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		1686F0E02C500FBD00841CDE /* QRScannerBridge.m in Sources */ = {isa = PBXBuildFile; fileRef = 1686F0DF2C500FBD00841CDE /* QRScannerBridge.m */; };
 		16E6646E2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */; };
 		16E884A52C5BD764003B7125 /* passport.json in Resources */ = {isa = PBXBuildFile; fileRef = 16E884A42C5BD764003B7125 /* passport.json */; };
-		7FD380C6602D2837D428451F /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59652A81D389205A1361E60D /* Pods_OpenPassport.framework */; };
+		7BABDA5678CC7A417F752C29 /* Pods_OpenPassport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06F9A782D9DE5156C60C40B9 /* Pods_OpenPassport.framework */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		905B70052A72767900AFA232 /* PassportReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 905B70042A72767900AFA232 /* PassportReader.swift */; };
 		905B70072A72774000AFA232 /* PassportReader.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B70062A72774000AFA232 /* PassportReader.m */; };
@@ -92,6 +92,7 @@
 		05D985FA2BB3344600F58EEA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = OpenPassport/Assets.xcassets; sourceTree = "<group>"; };
 		05EDEDC42B52D25D00AA51AD /* Prover.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Prover.m; sourceTree = "<group>"; };
 		05EDEDC52B52D25D00AA51AD /* Prover.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prover.swift; sourceTree = "<group>"; };
+		06F9A782D9DE5156C60C40B9 /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* OpenPassport.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OpenPassport.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = OpenPassport/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = OpenPassport/AppDelegate.mm; sourceTree = "<group>"; };
@@ -112,14 +113,13 @@
 		169349842CC694DA00166F21 /* OpenPassportDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassportDebug.entitlements; path = OpenPassport/OpenPassportDebug.entitlements; sourceTree = "<group>"; };
 		16E6646D2B8D292500FDD6A0 /* QKMRZScannerViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QKMRZScannerViewRepresentable.swift; sourceTree = "<group>"; };
 		16E884A42C5BD764003B7125 /* passport.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = passport.json; sourceTree = "<group>"; };
-		59652A81D389205A1361E60D /* Pods_OpenPassport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OpenPassport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = OpenPassport/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		905B70032A72767800AFA232 /* OpenPassport-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OpenPassport-Bridging-Header.h"; sourceTree = "<group>"; };
 		905B70042A72767900AFA232 /* PassportReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassportReader.swift; sourceTree = "<group>"; };
 		905B70062A72774000AFA232 /* PassportReader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PassportReader.m; sourceTree = "<group>"; };
 		905B70082A729CD400AFA232 /* OpenPassport.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = OpenPassport.entitlements; path = OpenPassport/OpenPassport.entitlements; sourceTree = "<group>"; };
-		BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
-		E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
+		9518C40B9DA455855D698100 /* Pods-OpenPassport.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.release.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.release.xcconfig"; sourceTree = "<group>"; };
+		D4981E6FD06457FEB4F609E8 /* Pods-OpenPassport.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OpenPassport.debug.xcconfig"; path = "Target Support Files/Pods-OpenPassport/Pods-OpenPassport.debug.xcconfig"; sourceTree = "<group>"; };
 		E56E082698598B41447667BB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = OpenPassport/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
@@ -140,7 +140,7 @@
 				05D985F62BB331AB00F58EEA /* libfr.a in Frameworks */,
 				167D934A2C91D2EA00530E6B /* libwitnesscalc_prove_rsa_65537_sha256.a in Frameworks */,
 				167D93462C91B1E100530E6B /* libwitnesscalc_register_rsa_65537_sha1.a in Frameworks */,
-				7FD380C6602D2837D428451F /* Pods_OpenPassport.framework in Frameworks */,
+				7BABDA5678CC7A417F752C29 /* Pods_OpenPassport.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -227,7 +227,7 @@
 				0569F35E2BBC98C9006670BD /* libfq.a */,
 				0569F35A2BBC900D006670BD /* librapidsnark.a */,
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				59652A81D389205A1361E60D /* Pods_OpenPassport.framework */,
+				06F9A782D9DE5156C60C40B9 /* Pods_OpenPassport.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -274,8 +274,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */,
-				BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */,
+				D4981E6FD06457FEB4F609E8 /* Pods-OpenPassport.debug.xcconfig */,
+				9518C40B9DA455855D698100 /* Pods-OpenPassport.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -287,15 +287,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "OpenPassport" */;
 			buildPhases = (
-				F5F9EF6F1544331166222AC0 /* [CP] Check Pods Manifest.lock */,
+				1C3B778186C749AEAB10A0B1 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				054340D12C71B2980014B445 /* Embed App Clips */,
-				C7FE745AC5EB974886200FC9 /* [CP] Embed Pods Frameworks */,
-				AAC3293A7CD5BBE029F392E0 /* [CP] Copy Pods Resources */,
+				0C6411FE06C61E7F495D9204 /* [CP] Embed Pods Frameworks */,
+				DAB2FFB78D69B620A585FF8C /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -369,24 +369,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		AAC3293A7CD5BBE029F392E0 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C7FE745AC5EB974886200FC9 /* [CP] Embed Pods Frameworks */ = {
+		0C6411FE06C61E7F495D9204 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -403,7 +386,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F5F9EF6F1544331166222AC0 /* [CP] Check Pods Manifest.lock */ = {
+		1C3B778186C749AEAB10A0B1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -423,6 +406,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DAB2FFB78D69B620A585FF8C /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-OpenPassport/Pods-OpenPassport-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -492,7 +492,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E244EB5C74C8D2970211FB45 /* Pods-OpenPassport.debug.xcconfig */;
+			baseConfigurationReference = D4981E6FD06457FEB4F609E8 /* Pods-OpenPassport.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -633,7 +633,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BD6C1525255EAD2C91B81D08 /* Pods-OpenPassport.release.xcconfig */;
+			baseConfigurationReference = 9518C40B9DA455855D698100 /* Pods-OpenPassport.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/app/ios/PassportReader.swift
+++ b/app/ios/PassportReader.swift
@@ -97,7 +97,7 @@ class PassportReader: NSObject{
         // let masterListURL = Bundle.main.url(forResource: "masterList", withExtension: ".pem")
         // passportReader.setMasterListURL( masterListURL! )
 
-        let passport = try await passportReader.readPassport( mrzKey: mrzKey, customDisplayMessage: customMessageHandler)
+        let passport = try await passportReader.readPassport( mrzKey: mrzKey, tags: [.COM, .DG1, .SOD], customDisplayMessage: customMessageHandler)
 
         var ret = [String:String]()
         print("documentType", passport.documentType)
@@ -118,13 +118,13 @@ class PassportReader: NSObject{
         ret["phoneNumber"] = passport.phoneNumber
         ret["personalNumber"] = passport.personalNumber
 
-        let passportPhotoData = passport.passportPhoto // [UInt8]
-        if let passportPhotoData = passport.passportPhoto {
-          let data = Data(passportPhotoData)
-          let base64String = data.base64EncodedString()
+        // let passportPhotoData = passport.passportPhoto // [UInt8]
+        // if let passportPhotoData = passport.passportPhoto {
+        //   let data = Data(passportPhotoData)
+        //   let base64String = data.base64EncodedString()
           
-          ret["passportPhoto"] = base64String 
-        }
+        //   ret["passportPhoto"] = base64String 
+        // }
 
         // documentSigningCertificate
         // countrySigningCertificate

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -24,7 +24,7 @@ target 'OpenPassport' do
   config = use_native_modules!
 
   use_frameworks!
-  pod 'NFCPassportReader', git: 'https://github.com/0xturboblitz/NFCPassportReader.git', commit: 'e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d'
+  pod 'NFCPassportReader', git: 'https://github.com/thomas-senechal/NFCPassportReader', commit: '8e72f0a2d3ca3bede00304bd22ed10829535dd53'
   pod 'QKMRZScanner'
   pod 'RNFS', :path => '../node_modules/react-native-fs'
   pod 'lottie-ios'

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -24,7 +24,7 @@ target 'OpenPassport' do
   config = use_native_modules!
 
   use_frameworks!
-  pod 'NFCPassportReader', git: 'https://github.com/thomas-senechal/NFCPassportReader', commit: '8e72f0a2d3ca3bede00304bd22ed10829535dd53'
+  pod 'NFCPassportReader', git: 'https://github.com/zk-passport/NFCPassportReader', commit: '8e72f0a2d3ca3bede00304bd22ed10829535dd53'
   pod 'QKMRZScanner'
   pod 'RNFS', :path => '../node_modules/react-native-fs'
   pod 'lottie-ios'

--- a/app/ios/Podfile
+++ b/app/ios/Podfile
@@ -24,7 +24,7 @@ target 'OpenPassport' do
   config = use_native_modules!
 
   use_frameworks!
-  pod 'NFCPassportReader', git: 'https://github.com/0xturboblitz/NFCPassportReader.git', commit: '0a8e26d56f5f85f698b67c5df5ea9ecbb53cbc45'
+  pod 'NFCPassportReader', git: 'https://github.com/0xturboblitz/NFCPassportReader.git', commit: 'e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d'
   pod 'QKMRZScanner'
   pod 'RNFS', :path => '../node_modules/react-native-fs'
   pod 'lottie-ios'

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1506,7 +1506,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - lottie-ios
-  - NFCPassportReader (from `https://github.com/0xturboblitz/NFCPassportReader.git`, commit `0a8e26d56f5f85f698b67c5df5ea9ecbb53cbc45`)
+  - NFCPassportReader (from `https://github.com/0xturboblitz/NFCPassportReader.git`, commit `e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d`)
   - QKMRZScanner
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -1603,7 +1603,7 @@ EXTERNAL SOURCES:
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   NFCPassportReader:
-    :commit: 0a8e26d56f5f85f698b67c5df5ea9ecbb53cbc45
+    :commit: e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d
     :git: https://github.com/0xturboblitz/NFCPassportReader.git
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
@@ -1744,7 +1744,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   NFCPassportReader:
-    :commit: 0a8e26d56f5f85f698b67c5df5ea9ecbb53cbc45
+    :commit: e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d
     :git: https://github.com/0xturboblitz/NFCPassportReader.git
   SwiftQRScanner:
     :commit: fddcabcb431cd6110cea0394660082661dbafa7e
@@ -1832,8 +1832,8 @@ SPEC CHECKSUMS:
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
   SwiftQRScanner: e85a25f9b843e9231dab89a96e441472fe54a724
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
-  Yoga: b05994d1933f507b0a28ceaa4fdb968dc18da178
+  Yoga: a9ef4f5c2cd79ad812110525ef61048be6a582a4
 
-PODFILE CHECKSUM: cc6778e0dcd4c510b705f4dc458411547dc1d00c
+PODFILE CHECKSUM: 05707ac610b4b4ca83797bdae88a7add1b5e95c4
 
 COCOAPODS: 1.16.2

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -7,9 +7,9 @@ PODS:
   - fmt (9.1.0)
   - glog (0.3.5)
   - lottie-ios (4.5.0)
-  - NFCPassportReader (2.0.3):
-    - OpenSSL-Universal (= 1.1.1100)
-  - OpenSSL-Universal (1.1.1100)
+  - NFCPassportReader (2.1.1):
+    - OpenSSL-Universal (= 1.1.1900)
+  - OpenSSL-Universal (1.1.1900)
   - QKMRZParser (2.0.0)
   - QKMRZScanner (3.0.0):
     - QKMRZParser (~> 2.0.0)
@@ -1506,7 +1506,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - lottie-ios
-  - NFCPassportReader (from `https://github.com/0xturboblitz/NFCPassportReader.git`, commit `e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d`)
+  - NFCPassportReader (from `https://github.com/thomas-senechal/NFCPassportReader`, commit `8e72f0a2d3ca3bede00304bd22ed10829535dd53`)
   - QKMRZScanner
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -1603,8 +1603,8 @@ EXTERNAL SOURCES:
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   NFCPassportReader:
-    :commit: e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d
-    :git: https://github.com/0xturboblitz/NFCPassportReader.git
+    :commit: 8e72f0a2d3ca3bede00304bd22ed10829535dd53
+    :git: https://github.com/thomas-senechal/NFCPassportReader
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -1744,8 +1744,8 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   NFCPassportReader:
-    :commit: e07871925bc9f7bd3ec5a5c0fe4242d4f74e060d
-    :git: https://github.com/0xturboblitz/NFCPassportReader.git
+    :commit: 8e72f0a2d3ca3bede00304bd22ed10829535dd53
+    :git: https://github.com/thomas-senechal/NFCPassportReader
   SwiftQRScanner:
     :commit: fddcabcb431cd6110cea0394660082661dbafa7e
     :git: https://github.com/vinodiOS/SwiftQRScanner
@@ -1758,8 +1758,8 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  NFCPassportReader: a160b80e3df3b5325c13902f90405f5eef7520b3
-  OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
+  NFCPassportReader: e931c61c189e08a4b4afa0ed4014af19eab2f129
+  OpenSSL-Universal: 84efb8a29841f2764ac5403e0c4119a28b713346
   QKMRZParser: 6b419b6f07d6bff6b50429b97de10846dc902c29
   QKMRZScanner: cf2348fd6ce441e758328da4adf231ef2b51d769
   RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
@@ -1834,6 +1834,6 @@ SPEC CHECKSUMS:
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
   Yoga: a9ef4f5c2cd79ad812110525ef61048be6a582a4
 
-PODFILE CHECKSUM: 05707ac610b4b4ca83797bdae88a7add1b5e95c4
+PODFILE CHECKSUM: 0d44c642d939bf6fc8087cefee2a4f313dc5f2e8
 
 COCOAPODS: 1.16.2

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -1506,7 +1506,7 @@ DEPENDENCIES:
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - lottie-ios
-  - NFCPassportReader (from `https://github.com/thomas-senechal/NFCPassportReader`, commit `8e72f0a2d3ca3bede00304bd22ed10829535dd53`)
+  - NFCPassportReader (from `https://github.com/zk-passport/NFCPassportReader`, commit `8e72f0a2d3ca3bede00304bd22ed10829535dd53`)
   - QKMRZScanner
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -1604,7 +1604,7 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   NFCPassportReader:
     :commit: 8e72f0a2d3ca3bede00304bd22ed10829535dd53
-    :git: https://github.com/thomas-senechal/NFCPassportReader
+    :git: https://github.com/zk-passport/NFCPassportReader
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -1745,7 +1745,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   NFCPassportReader:
     :commit: 8e72f0a2d3ca3bede00304bd22ed10829535dd53
-    :git: https://github.com/thomas-senechal/NFCPassportReader
+    :git: https://github.com/zk-passport/NFCPassportReader
   SwiftQRScanner:
     :commit: fddcabcb431cd6110cea0394660082661dbafa7e
     :git: https://github.com/vinodiOS/SwiftQRScanner
@@ -1834,6 +1834,6 @@ SPEC CHECKSUMS:
   SwiftyTesseract: 1f3d96668ae92dc2208d9842c8a59bea9fad2cbb
   Yoga: a9ef4f5c2cd79ad812110525ef61048be6a582a4
 
-PODFILE CHECKSUM: 0d44c642d939bf6fc8087cefee2a4f313dc5f2e8
+PODFILE CHECKSUM: a5761927116120f511f409f5249a18a8c626545c
 
 COCOAPODS: 1.16.2

--- a/app/src/screens/NextScreen.tsx
+++ b/app/src/screens/NextScreen.tsx
@@ -46,7 +46,7 @@ const NextScreen: React.FC = () => {
             h={height > 750 ? 190 : 130}
             borderRadius={height > 750 ? '$7' : '$6'}
             source={{
-              uri: passportData?.mockUser
+              uri: passportData?.mockUser || !!!passportData?.photoBase64
                 ? USER_PROFILE
                 : passportData?.photoBase64 ?? USER_PROFILE,
             }}

--- a/app/src/utils/nfcScanner.ts
+++ b/app/src/utils/nfcScanner.ts
@@ -215,7 +215,9 @@ const handleResponseIOS = async (
     eContent: concatenatedDataHashesArraySigned,
     signedAttr: signedEContentArray,
     encryptedDigest: encryptedDigestArray,
-    photoBase64: 'data:image/jpeg;base64,' + parsed.passportPhoto,
+    photoBase64: parsed?.passportPhoto
+      ? 'data:image/jpeg;base64,' + parsed?.passportPhoto
+      : '',
     mockUser: false,
   };
 
@@ -283,7 +285,7 @@ const handleResponseAndroid = async (
     eContent: JSON.parse(encapContent),
     signedAttr: JSON.parse(eContent),
     encryptedDigest: JSON.parse(encryptedDigest),
-    photoBase64: photo.base64,
+    photoBase64: photo?.base64 ?? '',
     mockUser: false,
   };
 

--- a/app/src/utils/nfcScanner.ts
+++ b/app/src/utils/nfcScanner.ts
@@ -47,10 +47,11 @@ export const scan = async (
 
 const scanAndroid = async (
   setModalProofStep: (modalProofStep: number) => void,
-  startTime: number
+  startTime: number,
 ) => {
   const { passportNumber, dateOfBirth, dateOfExpiry } = useUserStore.getState();
-  const { toast, setNfcSheetIsOpen, trackEvent } = useNavigationStore.getState();
+  const { toast, setNfcSheetIsOpen, trackEvent } =
+    useNavigationStore.getState();
   setNfcSheetIsOpen(true);
 
   try {
@@ -97,13 +98,12 @@ const scanAndroid = async (
         duration_ms: Date.now() - startTime,
       });
     }
-
   }
 };
 
 const scanIOS = async (
   setModalProofStep: (modalProofStep: number) => void,
-  startTime: number
+  startTime: number,
 ) => {
   const { passportNumber, dateOfBirth, dateOfExpiry } = useUserStore.getState();
   const { toast, trackEvent } = useNavigationStore.getState();
@@ -205,7 +205,6 @@ const handleResponseIOS = async (
   const encryptedDigestArray = Array.from(
     Buffer.from(signatureBase64, 'base64'),
   ).map(byte => (byte > 127 ? byte - 256 : byte));
-
 
   const passportData = {
     mrz,
@@ -339,8 +338,8 @@ const handleResponseAndroid = async (
 async function parsePassportDataAsync(passportData: PassportData) {
   const { trackEvent } = useNavigationStore.getState();
   const parsedPassportData = parsePassportData(passportData);
-  useUserStore.getState().setPassportMetadata(parsedPassportData);
-  useUserStore.getState().registerPassportData(passportData);
+  await useUserStore.getState().setPassportMetadata(parsedPassportData);
+  await useUserStore.getState().registerPassportData(passportData);
   trackEvent('Passport Parsed', {
     success: true,
     data_groups: parsedPassportData.dataGroups,
@@ -362,8 +361,9 @@ async function parsePassportDataAsync(passportData: PassportData) {
     csca_signature: parsedPassportData.cscaSignature,
     csca_salt_length: parsedPassportData.cscaSaltLength,
     csca_curve_or_exponent: parsedPassportData.cscaCurveOrExponent,
-    csca_signature_algorithm_bits: parsedPassportData.cscaSignatureAlgorithmBits,
-    dsc: parsedPassportData.dsc
+    csca_signature_algorithm_bits:
+      parsedPassportData.cscaSignatureAlgorithmBits,
+    dsc: parsedPassportData.dsc,
   });
 
   useNavigationStore.getState().setSelectedTab('next');


### PR DESCRIPTION
This PR removes DG2 reading from the app and replaces the passport photo display with the one used for Mock Passports

I kept most of the code by commenting it out, tell me if you prefer me to remove it entirely and clean the code properly

I changed the iOS NFC Passport reading lib to https://github.com/thomas-senechal/NFCPassportReader/
Which is a fork of the original library, with the fixes we had in the previous fork, might help to fix some reading issues we have with some passports

I tested it on an Android and an iOS devices, worked on both
