### PR TITLE
Sanity checking pubkey prefixes

### DIFF
--- a/circuits/circuits/utils/passport/checkRSAPrefix.circom
+++ b/circuits/circuits/utils/passport/checkRSAPrefix.circom
@@ -1,0 +1,46 @@
+pragma circom 2.1.9;
+
+include "circomlib/circuits/comparators.circom";
+include "constants.circom";
+
+/// @title CheckRSAPrefix
+/// @notice Extracts and verifies RSA prefix from a byte array
+/// @param prefixLength Length of the RSA prefix to check
+/// @param arrayLength Length of the input array containing the prefix
+/// @input array Array containing the prefix at the start
+/// @output is_valid 1 if extracted prefix matches any allowed prefix, 0 otherwise
+template CheckRSAPrefix(prefixLength, arrayLength) {
+    signal input array[arrayLength];
+
+    signal prefix_bytes[prefixLength];
+    for (var i = 0; i < prefixLength; i++) {
+        prefix_bytes[i] <== array[i];
+    }
+
+    var rsaPrefixes[3][5] = getRSAPrefixes();
+    signal candidateMatches[3];
+    signal byteMatches[3][prefixLength];
+    signal sum[3][prefixLength+1];
+    component cmp[3][prefixLength];
+    component eq[3];
+
+    for (var j = 0; j < 3; j++) {
+        sum[j][0] <== 0;
+        for (var i = 0; i < prefixLength; i++) {
+            cmp[j][i] = IsEqual();
+            cmp[j][i].in[0] <== prefix_bytes[i];
+            cmp[j][i].in[1] <== rsaPrefixes[j][i];
+            byteMatches[j][i] <== cmp[j][i].out;
+            sum[j][i+1] <== sum[j][i] + byteMatches[j][i];
+        }
+        eq[j] = IsEqual();
+        eq[j].in[0] <== sum[j][prefixLength];
+        eq[j].in[1] <== prefixLength;
+        candidateMatches[j] <== eq[j].out;
+    }
+    signal prefix_ok <== candidateMatches[0] + candidateMatches[1] + candidateMatches[2];
+    component gt = GreaterThan(4);
+    gt.in[0] <== prefix_ok;
+    gt.in[1] <== 0;
+    gt.out === 1;
+}

--- a/circuits/circuits/utils/passport/signatureAlgorithm.circom
+++ b/circuits/circuits/utils/passport/signatureAlgorithm.circom
@@ -509,37 +509,12 @@ function getExponentBits(signatureAlgorithm) {
     return 0;
 }
 
-/// @title GetPrefixLength
-/// @notice Returns the length of the prefix of the public key
-/// @param kLengthFactor is 1 for RSA and RSAPSS, 2 for ECDSA
-/// @output prefixLength Length of the prefix
-function getPrefixLength(kLengthFactor) {
-    if (kLengthFactor == 1) {
-        return 5;
-    } else if (kLengthFactor == 2) {
-        return 4;
-    }
-    return 5;
-}
+function getRSAPrefixes() {
+    var prefixes[3][5];
 
-// 0x0282020100 for RSA and RSAPSS
-// 0x03420004 for ECDSA
-function getPrefixInCSCA(kLengthFactor) {
-    if (kLengthFactor == 1) {
-        return [0x02, 0x82, 0x02, 0x01, 0x00];
-    } else if (kLengthFactor == 2) {
-        return [0x03, 0x42, 0x00, 0x04];
-    }
-    return [0x02, 0x82, 0x02, 0x01, 0x00];
-}
+    prefixes[0] = [0x02, 0x82, 0x01, 0x01, 0x00]; // 2048 bits
+    prefixes[1] = [0x02, 0x82, 0x02, 0x01, 0x00]; // 4096 bits
+    prefixes[2] = [0x02, 0x82, 0x01, 0x81, 0x00]; // 3072 bits
 
-// 0x0282010100 for RSA and RSAPSS
-// 0x033A0004 for ECDSA
-function getPrefixInDSC(kLengthFactor) {
-    if (kLengthFactor == 1) {
-        return [0x02, 0x82, 0x01, 0x01, 0x00];
-    } else if (kLengthFactor == 2) {
-        return [0x03, 0x3A, 0x00, 0x04];
-    }
-    return [0x02, 0x82, 0x01, 0x01, 0x00];
+    return prefixes;
 }

--- a/circuits/circuits/utils/passport/signatureAlgorithm.circom
+++ b/circuits/circuits/utils/passport/signatureAlgorithm.circom
@@ -508,3 +508,38 @@ function getExponentBits(signatureAlgorithm) {
     }
     return 0;
 }
+
+/// @title GetPrefixLength
+/// @notice Returns the length of the prefix of the public key
+/// @param kLengthFactor is 1 for RSA and RSAPSS, 2 for ECDSA
+/// @output prefixLength Length of the prefix
+function getPrefixLength(kLengthFactor) {
+    if (kLengthFactor == 1) {
+        return 5;
+    } else if (kLengthFactor == 2) {
+        return 4;
+    }
+    return 5;
+}
+
+// 0x0282020100 for RSA and RSAPSS
+// 0x03420004 for ECDSA
+function getPrefixInCSCA(kLengthFactor) {
+    if (kLengthFactor == 1) {
+        return [0x02, 0x82, 0x02, 0x01, 0x00];
+    } else if (kLengthFactor == 2) {
+        return [0x03, 0x42, 0x00, 0x04];
+    }
+    return [0x02, 0x82, 0x02, 0x01, 0x00];
+}
+
+// 0x0282010100 for RSA and RSAPSS
+// 0x033A0004 for ECDSA
+function getPrefixInDSC(kLengthFactor) {
+    if (kLengthFactor == 1) {
+        return [0x02, 0x82, 0x01, 0x01, 0x00];
+    } else if (kLengthFactor == 2) {
+        return [0x03, 0x3A, 0x00, 0x04];
+    }
+    return [0x02, 0x82, 0x01, 0x01, 0x00];
+}

--- a/circuits/tests/dsc/dsc.test.ts
+++ b/circuits/tests/dsc/dsc.test.ts
@@ -232,8 +232,6 @@ testSuite.forEach(({ sigAlg, hashFunction, domainParameter, keyLength }) => {
           Number(tamperedInputs.raw_dsc[tamperedInputs.raw_dsc.length - 1]) + 1
         ).toString();
 
-        console.log(JSON.stringify(Array.from(tamperedInputs.raw_dsc)));
-
         await circuit.calculateWitness(tamperedInputs);
         expect.fail('Expected an error but none was thrown.');
       } catch (error) {

--- a/circuits/tests/dsc/test_cases.ts
+++ b/circuits/tests/dsc/test_cases.ts
@@ -15,13 +15,13 @@ export const fullSigAlgs = [
     domainParameter: '65537',
     keyLength: '3072',
   },
-  {
-    sigAlg: 'rsapss',
-    hashFunction: 'sha256',
-    saltLen: '32',
-    domainParameter: '65537',
-    keyLength: '4096',
-  },
+  // {
+  //   sigAlg: 'rsapss',
+  //   hashFunction: 'sha256',
+  //   saltLen: '32',
+  //   domainParameter: '65537',
+  //   keyLength: '4096',
+  // }, // signed by CSCA using dsc_sha256_rsapss_65537_32_2048.circom, which was removed because not needed.
   {
     sigAlg: 'rsapss',
     hashFunction: 'sha512',

--- a/circuits/tests/register/register.test.ts
+++ b/circuits/tests/register/register.test.ts
@@ -265,15 +265,25 @@ testSuite.forEach(
 
       if (sigAlg.startsWith('rsa') || sigAlg.startsWith('rsapss')) {
         it('should fail if RSA public key prefix is invalid', async function () {
-          try {
-            const tamperedInputs = JSON.parse(JSON.stringify(inputs));
-            tamperedInputs.raw_dsc[tamperedInputs.dsc_pubKey_offset - 1] = 
-              (tamperedInputs.raw_dsc[tamperedInputs.dsc_pubKey_offset - 1] + 1).toString();
-            
-            await circuit.calculateWitness(tamperedInputs);
-            expect.fail('Expected an error but none was thrown.');
-          } catch (error: any) {
-            expect(error.message).to.include('Assert Failed');
+          const invalidPrefixes = [
+            [0x03, 0x82, 0x01, 0x01, 0x00],
+            [0x02, 0x83, 0x01, 0x01, 0x00],
+            [0x02, 0x82, 0x02, 0x02, 0x00]
+          ];
+
+          for (const invalidPrefix of invalidPrefixes) {
+            try {
+              const tamperedInputs = JSON.parse(JSON.stringify(inputs));
+              for (let i = 0; i < invalidPrefix.length; i++) {
+                tamperedInputs.raw_dsc[Number(tamperedInputs.dsc_pubKey_offset) - invalidPrefix.length + i] = 
+                  invalidPrefix[i].toString();
+              }
+              
+              await circuit.calculateWitness(tamperedInputs);
+              expect.fail('Expected an error but none was thrown.');
+            } catch (error: any) {
+              expect(error.message).to.include('Assert Failed');
+            }
           }
         });
 

--- a/circuits/tests/register/register.test.ts
+++ b/circuits/tests/register/register.test.ts
@@ -262,6 +262,38 @@ testSuite.forEach(
         expect(nullifierTampered).to.equal(nullifierValid);
         expect(commitmentTampered).to.not.be.equal(commitmentValid);
       });
+
+      if (sigAlg.startsWith('rsa') || sigAlg.startsWith('rsapss')) {
+        it('should fail if RSA public key prefix is invalid', async function () {
+          try {
+            const tamperedInputs = JSON.parse(JSON.stringify(inputs));
+            tamperedInputs.raw_dsc[tamperedInputs.dsc_pubKey_offset - 1] = 
+              (tamperedInputs.raw_dsc[tamperedInputs.dsc_pubKey_offset - 1] + 1).toString();
+            
+            await circuit.calculateWitness(tamperedInputs);
+            expect.fail('Expected an error but none was thrown.');
+          } catch (error: any) {
+            expect(error.message).to.include('Assert Failed');
+          }
+        });
+
+        it('should pass with valid RSA prefix for the key length', async function () {
+          const keyLengthToPrefix = {
+            2048: [0x02, 0x82, 0x01, 0x01, 0x00],
+            3072: [0x02, 0x82, 0x01, 0x81, 0x00], 
+            4096: [0x02, 0x82, 0x02, 0x01, 0x00]
+          };
+
+          const expectedPrefix = keyLengthToPrefix[keyLength];
+          
+          for (let i = 0; i < 5; i++) {
+            const prefixByte = parseInt(inputs.raw_dsc[Number(inputs.dsc_pubKey_offset) - 5 + i]);
+            expect(prefixByte)
+              .to.equal(expectedPrefix[i], 
+                `Prefix byte ${i} mismatch for ${keyLength} bit key`);
+          }
+        });
+      }
     });
   }
 );

--- a/common/src/utils/certificate_parsing/utils.ts
+++ b/common/src/utils/certificate_parsing/utils.ts
@@ -12,7 +12,7 @@ export const getSubjectKeyIdentifier = (cert: Certificate): string => {
     skiValue = skiValue.replace(/^(?:3016)?(?:0414)?/, '');
     return skiValue;
   } else {
-    console.log('\x1b[31m%s\x1b[0m', 'no subject key identifier found');
+    // console.log('\x1b[31m%s\x1b[0m', 'no subject key identifier found'); // it's no big deal if this is not found
     // do a sha1 of the certificate tbs
     const hash = sha256.create();
     hash.update(cert.tbsView);

--- a/registry/README.md
+++ b/registry/README.md
@@ -74,3 +74,13 @@ Build JSON files:
 ```
 ts-node src/buildJson.ts
 ```
+
+### Search sequences
+
+To run the scripts that search for specific sequences, run:
+```
+ts-node src/dsc/search_sequence_dsc.ts
+ts-node src/csca/search_sequence_csca.ts
+```
+
+Visualize certs here: [https://lapo.it/asn1js](https://lapo.it/asn1js)

--- a/registry/src/csca/search_sequence_csca.ts
+++ b/registry/src/csca/search_sequence_csca.ts
@@ -1,0 +1,91 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseCertificateSimple } from '../../../common/src/utils/certificate_parsing/parseCertificateSimple';
+
+// Function to convert DER to PEM
+function derToPem(derBuffer: Buffer): string {
+  const base64 = derBuffer.toString('base64');
+  const pem = `-----BEGIN CERTIFICATE-----\n${base64.match(/.{1,64}/g)!.join('\n')}\n-----END CERTIFICATE-----\n`;
+  return pem;
+}
+
+export async function extractMasterlistCsca() {
+  const csca_path = path.join(__dirname, '..', '..', 'outputs', 'csca');
+  const uniqueCertsDir = path.join(csca_path, 'pem_masterlist');
+
+  if (!fs.existsSync(uniqueCertsDir)) {
+    console.error(`Directory ${uniqueCertsDir} does not exist.`);
+    return;
+  }
+
+  const certificateFiles = fs.readdirSync(uniqueCertsDir).filter(file => file.endsWith('.pem'));
+  const certArray: string[] = certificateFiles.map(file => {
+    const filePath = path.join(uniqueCertsDir, file);
+    return fs.readFileSync(filePath, 'utf-8');
+  });
+
+  console.log(`Read ${certArray.length} certificates.`);
+
+  const sequenceMatchCounts = [0, 0, 0]; // Initialize counters for each sequence
+  const multipleMatches = [];
+
+  for (let i = 0; i < certArray.length; i++) {
+    const pemContent = certArray[i];
+    const parsed = parseCertificateSimple(pemContent);
+    if (parsed.signatureAlgorithm === 'ecdsa') {
+      continue;
+    }
+    
+    // if (i === 247) {
+    //   console.log("pemContent", pemContent);
+    // }
+
+    let matchCount = 0;
+    
+    const tbsBytesArray = Array.from(parsed.tbsBytes);
+    if (parsed.signatureAlgorithm === 'rsa' || parsed.signatureAlgorithm === 'rsapss') {
+      const sequences = [
+        [2, 130, 1, 1, 0], // 2048 bits, 8 matches
+        [2, 130, 2, 1, 0], // 2048 bits, 509 matches
+        [2, 130, 1, 129, 0], // 3072 bits, 81 matches
+        // [2, 130, 3, 1, 0], // 6144 bits, 10 matches. Moldova. Not supported.
+      ];
+      
+      sequences.forEach((sequence, index) => {
+        const sequenceString = sequence.join(',');
+        const tbsString = tbsBytesArray.join(',');
+        const currentMatchCount = (tbsString.match(new RegExp(sequenceString, 'g')) || []).length;
+        if (currentMatchCount > 0) {
+          matchCount += currentMatchCount;
+          sequenceMatchCounts[index] += currentMatchCount;
+          if (currentMatchCount > 1) {
+            multipleMatches.push(i, currentMatchCount, sequenceString);
+          }
+        }
+      });
+
+      if (matchCount > 1) {
+        console.log(`Certificate ${i} with ${parsed.signatureAlgorithm} has sequences matched ${matchCount} times.`);
+        console.log('tbsBytesArray:', JSON.parse(JSON.stringify(tbsBytesArray)));
+      }
+
+      if (matchCount === 0) {
+        console.log(`Certificate ${i} with ${parsed.signatureAlgorithm} missing expected byte sequence`);
+      }
+    }
+
+    if (i > 0 && i % 100 === 0) {
+      console.log(`Processed ${i} certificates...`);
+    }
+  }
+
+  // Log the number of matches for each sequence
+  console.log(`Sequence match counts:`);
+  console.log(`[2, 130, 1, 1, 0]: ${sequenceMatchCounts[0]}`);
+  console.log(`[2, 130, 2, 1, 0]: ${sequenceMatchCounts[1]}`);
+  console.log(`[2, 130, 1, 129, 0]: ${sequenceMatchCounts[2]}`);
+
+  console.log(`Certificate with multiple sequence matches: ${multipleMatches}`);
+}
+
+extractMasterlistCsca();

--- a/registry/src/csca/search_sequence_csca.ts
+++ b/registry/src/csca/search_sequence_csca.ts
@@ -46,7 +46,7 @@ export async function extractMasterlistCsca() {
     if (parsed.signatureAlgorithm === 'rsa' || parsed.signatureAlgorithm === 'rsapss') {
       const sequences = [
         [2, 130, 1, 1, 0], // 2048 bits, 8 matches
-        [2, 130, 2, 1, 0], // 2048 bits, 509 matches
+        [2, 130, 2, 1, 0], // 4096 bits, 509 matches
         [2, 130, 1, 129, 0], // 3072 bits, 81 matches
         // [2, 130, 3, 1, 0], // 6144 bits, 10 matches. Moldova. Not supported.
       ];

--- a/registry/src/dsc/extract_masterlist_dsc.ts
+++ b/registry/src/dsc/extract_masterlist_dsc.ts
@@ -30,5 +30,3 @@ export async function extractMasterlistDsc() {
 
   console.log(`Extracted ${certificates.length} certificates.`);
 }
-
-extractMasterlistDsc();

--- a/registry/src/dsc/search_sequence_dsc.ts
+++ b/registry/src/dsc/search_sequence_dsc.ts
@@ -38,7 +38,7 @@ export async function extractMasterlistDsc() {
     if (parsed.signatureAlgorithm === 'rsa' || parsed.signatureAlgorithm === 'rsapss') {
       const sequences = [
         [2, 130, 1, 1, 0], // 2048 bits, 23963 matches
-        [2, 130, 2, 1, 0], // 2048 bits, 200 matches
+        [2, 130, 2, 1, 0], // 4096 bits, 200 matches
         [2, 130, 1, 129, 0], // 3072 bits, 528 matches
         // a few certs between 23502 and 23527 and around have 1024 bits
         // they have [2, 129, 129, 0, 210/186/194...]

--- a/registry/src/dsc/search_sequence_dsc.ts
+++ b/registry/src/dsc/search_sequence_dsc.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseCertificateSimple } from '../../../common/src/utils/certificate_parsing/parseCertificateSimple';
+
+export async function extractMasterlistDsc() {
+  // Read pem certificates from the output directory
+  const pem_path = path.join(__dirname, '..', '..', 'outputs', 'dsc', 'pem_masterlist');
+
+  if (!fs.existsSync(pem_path)) {
+    console.error(`Directory ${pem_path} does not exist.`);
+    return;
+  }
+
+  const certificateFiles = fs.readdirSync(pem_path).filter(file => file.endsWith('.pem'));
+  const certificates: string[] = certificateFiles.map(file => {
+    const filePath = path.join(pem_path, file);
+    return fs.readFileSync(filePath, 'utf-8');
+  });
+
+  console.log(`Read ${certificates.length} certificates.`);
+
+  const overallSequenceMatchCounts = [0, 0, 0]; // Initialize overall counters for each sequence
+  const multipleMatches = [];
+
+  for (let i = 0; i < certificates.length; i++) {
+    const pemContent = certificates[i];
+    const parsed = parseCertificateSimple(pemContent);
+    if (parsed.signatureAlgorithm === 'ecdsa') {
+      continue;
+    }
+
+    // if (i === 24100) {
+    //   console.log("pemContent", pemContent);
+    //   return
+    // }
+
+    const tbsBytesArray = Array.from(parsed.tbsBytes);
+    if (parsed.signatureAlgorithm === 'rsa' || parsed.signatureAlgorithm === 'rsapss') {
+      const sequences = [
+        [2, 130, 1, 1, 0], // 2048 bits, 23963 matches
+        [2, 130, 2, 1, 0], // 2048 bits, 200 matches
+        [2, 130, 1, 129, 0], // 3072 bits, 528 matches
+        // a few certs between 23502 and 23527 and around have 1024 bits
+        // they have [2, 129, 129, 0, 210/186/194...]
+        // we don't support them.
+      ];
+
+      let matchCount = 0;
+
+      sequences.forEach((sequence, index) => {
+        const sequenceString = sequence.join(',');
+        const tbsString = tbsBytesArray.join(',');
+        const currentMatchCount = (tbsString.match(new RegExp(sequenceString, 'g')) || []).length;
+        if (currentMatchCount > 0) {
+          matchCount += currentMatchCount;
+          overallSequenceMatchCounts[index] += currentMatchCount;
+          if (currentMatchCount > 1) {
+            multipleMatches.push(i, currentMatchCount, sequenceString);
+          }
+        }
+      });
+
+      if (matchCount > 1) {
+        console.log(`Certificate ${i} with ${parsed.signatureAlgorithm} has sequences matched ${matchCount} times.`);
+        console.log('tbsBytesArray:', JSON.parse(JSON.stringify(tbsBytesArray)));
+      }
+
+      if (matchCount === 0) {
+        console.log(`Certificate ${i} with ${parsed.signatureAlgorithm} missing expected byte sequence`);
+      }
+    }
+
+    if (i > 0 && i % 100 === 0) {
+      console.log(`Processed ${i} certificates...`);
+    }
+  }
+
+  // Log the overall number of matches for each sequence
+  console.log(`Overall sequence match counts:`);
+  console.log(`[2, 130, 1, 1, 0]: ${overallSequenceMatchCounts[0]}`);
+  console.log(`[2, 130, 2, 1, 0]: ${overallSequenceMatchCounts[1]}`);
+  console.log(`[2, 130, 1, 129, 0]: ${overallSequenceMatchCounts[2]}`);
+
+  console.log(`Certificate with multiple sequence matches: ${multipleMatches}`);
+}
+
+extractMasterlistDsc();


### PR DESCRIPTION
Checking pubkey prefixes for RSA.
```
2048 bits: [0x02, 0x82, 0x01, 0x01, 0x00]
3072 bits: [0x02, 0x82, 0x01, 0x81, 0x00] 
4096 bits: [0x02, 0x82, 0x02, 0x01, 0x00]
```
Not checking for ECDSA as the chances of finding a valid EC point are low.

Added scripts to identify sequences in certificates. It seems that no currently known certificate includes two valid prefixes.